### PR TITLE
Instance Initializer

### DIFF
--- a/Polymorphism/src/main/java/initializer_block/A.java
+++ b/Polymorphism/src/main/java/initializer_block/A.java
@@ -1,0 +1,26 @@
+package initializer_block;
+
+class A{
+    A(){
+        System.out.println("parent class constructor invoked");
+    }
+}
+
+class B3 extends A{
+    B3(){
+        super();
+        System.out.println("child class constructor invoked");
+    }
+
+    B3(int a){
+        super();
+        System.out.println("child class constructor invoked "+a);
+    }
+
+    {System.out.println("instance initializer block is invoked");}
+
+    public static void main(String args[]){
+        B3 b1=new B3();
+        B3 b2=new B3(10);
+    }
+}


### PR DESCRIPTION
Instance Initializer block is used to initialize the instance data member. It run each time when object of the class is created.